### PR TITLE
Feat mouse highlighting and selecting

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "author": "Misha Moroshko <michael.moroshko@gmail.com>",
   "scripts": {
+    "postinstall": "npm run dist",
     "start": "mkdir -p demo/dist && npm run copy-static-files && node server",
     "prettier": "prettier --single-quote --write \".*.js\" \"*.js\" \"demo/src/**/*.js\" \"demo/standalone/app.js\" \"src/**/*.js\" \"test/**/*.js\"",
     "lint": "eslint src test demo/src demo/standalone/app.js server.js webpack.*.js",

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -121,6 +121,8 @@ export default class Autosuggest extends Component {
 
   componentWillReceiveProps(nextProps) {
     if (
+      nextProps.highlightedSuggestionIndex !== this.props.highlightFirstSuggestion &&
+      nextProps.highlightedSectionIndex !== this.props.highlightedSectionIndex &&
       !(
         nextProps.highlightedSuggestionIndex === this.state.highlightedSuggestionIndex &&
         nextProps.highlightedSectionIndex === this.state.highlightedSectionIndex
@@ -376,15 +378,37 @@ export default class Autosuggest extends Component {
       clickedSuggestion
     );
 
-    // this.maybeCallOnChange(event, clickedSuggestionValue, 'click');
-    // this.onSuggestionSelected(event, {
-    //   suggestion: clickedSuggestion,
-    //   suggestionValue: clickedSuggestionValue,
-    //   suggestionIndex: suggestionIndex,
-    //   sectionIndex,
-    //   method: 'click'
-    // });
     this.updateHighlightedSuggestion(sectionIndex, suggestionIndex);
+
+    if (focusInputOnSuggestionClick === true) {
+      this.input.focus();
+    } else {
+      this.onBlur();
+    }
+
+    setTimeout(() => {
+      this.justSelectedSuggestion = false;
+    });
+  };
+
+  onSuggestionDoubleClick = event => {
+    const { alwaysRenderSuggestions, focusInputOnSuggestionClick } = this.props;
+    const { sectionIndex, suggestionIndex } = this.getSuggestionIndices(
+      this.findSuggestionElement(event.target)
+    );
+    const clickedSuggestion = this.getSuggestion(sectionIndex, suggestionIndex);
+    const clickedSuggestionValue = this.props.getSuggestionValue(
+      clickedSuggestion
+    );
+
+    this.maybeCallOnChange(event, clickedSuggestionValue, 'click');
+    this.onSuggestionSelected(event, {
+      suggestion: clickedSuggestion,
+      suggestionValue: clickedSuggestionValue,
+      suggestionIndex: suggestionIndex,
+      sectionIndex,
+      method: 'doubleClick'
+    });
 
     if (!alwaysRenderSuggestions) {
       this.closeSuggestions();
@@ -421,7 +445,8 @@ export default class Autosuggest extends Component {
       'data-suggestion-index': itemIndex,
       onMouseDown: this.onSuggestionMouseDown,
       onTouchStart: this.onSuggestionMouseDown, // Because on iOS `onMouseDown` is not triggered
-      onClick: this.onSuggestionClick
+      onClick: this.onSuggestionClick,
+      onDoubleClick: this.onSuggestionDoubleClick,
     };
   };
 

--- a/src/Autosuggest.js
+++ b/src/Autosuggest.js
@@ -92,18 +92,20 @@ export default class Autosuggest extends Component {
     multiSection: false,
     focusInputOnSuggestionClick: true,
     highlightFirstSuggestion: false,
+    highlightedSectionIndex: null,
+    highlightedSuggestionIndex: null,
     theme: defaultTheme,
     id: '1'
   };
 
-  constructor({ alwaysRenderSuggestions }) {
+  constructor({ alwaysRenderSuggestions, highlightedSectionIndex, highlightedSuggestionIndex }) {
     super();
 
     this.state = {
       isFocused: false,
       isCollapsed: !alwaysRenderSuggestions,
-      highlightedSectionIndex: null,
-      highlightedSuggestionIndex: null,
+      highlightedSectionIndex: highlightedSectionIndex,
+      highlightedSuggestionIndex: highlightedSuggestionIndex,
       valueBeforeUpDown: null
     };
 
@@ -118,6 +120,18 @@ export default class Autosuggest extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
+    if (
+      !(
+        nextProps.highlightedSuggestionIndex === this.state.highlightedSuggestionIndex &&
+        nextProps.highlightedSectionIndex === this.state.highlightedSectionIndex
+      )
+    ) {
+      this.setState({
+        highlightedSuggestionIndex: nextProps.highlightedSuggestionIndex,
+        highlightedSectionIndex: nextProps.highlightedSectionIndex,
+      });
+    }
+
     if (shallowEqualArrays(nextProps.suggestions, this.props.suggestions)) {
       if (
         nextProps.highlightFirstSuggestion &&
@@ -317,10 +331,6 @@ export default class Autosuggest extends Component {
     }
   };
 
-  onSuggestionMouseEnter = (event, { sectionIndex, itemIndex }) => {
-    this.updateHighlightedSuggestion(sectionIndex, itemIndex);
-  };
-
   highlightFirstSuggestion = () => {
     this.updateHighlightedSuggestion(this.props.multiSection ? 0 : null, 0);
   };
@@ -366,14 +376,15 @@ export default class Autosuggest extends Component {
       clickedSuggestion
     );
 
-    this.maybeCallOnChange(event, clickedSuggestionValue, 'click');
-    this.onSuggestionSelected(event, {
-      suggestion: clickedSuggestion,
-      suggestionValue: clickedSuggestionValue,
-      suggestionIndex: suggestionIndex,
-      sectionIndex,
-      method: 'click'
-    });
+    // this.maybeCallOnChange(event, clickedSuggestionValue, 'click');
+    // this.onSuggestionSelected(event, {
+    //   suggestion: clickedSuggestion,
+    //   suggestionValue: clickedSuggestionValue,
+    //   suggestionIndex: suggestionIndex,
+    //   sectionIndex,
+    //   method: 'click'
+    // });
+    this.updateHighlightedSuggestion(sectionIndex, suggestionIndex);
 
     if (!alwaysRenderSuggestions) {
       this.closeSuggestions();
@@ -398,25 +409,16 @@ export default class Autosuggest extends Component {
 
     this.setState({
       isFocused: false,
-      highlightedSectionIndex: null,
-      highlightedSuggestionIndex: null,
-      valueBeforeUpDown: null,
       isCollapsed: !shouldRender
     });
 
     onBlur && onBlur(this.blurEvent, { highlightedSuggestion });
   };
 
-  resetHighlightedSuggestionOnMouseLeave = () => {
-    this.resetHighlightedSuggestion(false); // shouldResetValueBeforeUpDown
-  };
-
   itemProps = ({ sectionIndex, itemIndex }) => {
     return {
       'data-section-index': sectionIndex,
       'data-suggestion-index': itemIndex,
-      onMouseEnter: this.onSuggestionMouseEnter,
-      onMouseLeave: this.resetHighlightedSuggestionOnMouseLeave,
       onMouseDown: this.onSuggestionMouseDown,
       onTouchStart: this.onSuggestionMouseDown, // Because on iOS `onMouseDown` is not triggered
       onClick: this.onSuggestionClick


### PR DESCRIPTION
It's a hotfix for the needs of XOD IDE. What has changed:
- Mouse move/enter/leave now doesn't trigger highlighting of items
- Mouse click highlights item
- Mouse double click selects item
- Component could take highlighted suggestion and section indexes as props

It breaks some functionality in the original `react-autosuggest`, so it's not a PR into the original repo.